### PR TITLE
Exclude header and navbar on /dashboard route

### DIFF
--- a/src/Routes/DashboardRouter.jsx
+++ b/src/Routes/DashboardRouter.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Route, Routes } from "react-router-dom";
+import { Dashboard } from "../pages/Dashboard";
+
+export const DashboardRouter = () => {
+  return (
+    <Routes>
+      {/* <Route path="/dashboard" element={<Dashboard />} /> */}
+    </Routes>
+  );
+};

--- a/src/Routes/Router.jsx
+++ b/src/Routes/Router.jsx
@@ -10,6 +10,7 @@ import { EventDetails } from "../pages/EventDetails";
 import { CreateEventForm } from "../components/CreateEventForm";
 import CreateEventPage from "../pages/CreateEventPage";
 import MyTicketsPage from "../components/Tickets/MyTickets";
+import {Dashboard}  from "../pages/Dashboard";
 
 export const Router = () => {
   return (
@@ -23,6 +24,7 @@ export const Router = () => {
       <Route path="/auth/signin" element={<Login />} />
       <Route path="/auth/register" element={<SignUp />} />
       <Route path="/create-event" element={<CreateEventForm />} />
+      <Route path="/dashboard" element={<Dashboard />} />
     </Routes>
   );
 };

--- a/src/components/Dashboard/Aside.jsx
+++ b/src/components/Dashboard/Aside.jsx
@@ -1,0 +1,37 @@
+// Aside.js
+
+import React from "react";
+import { Link } from "react-router-dom"; // If you're using React Router
+
+const Aside = () => {
+  return (
+    <aside className="bg-primaryColor text-white w-1/4 min-h-screen">
+      <div className="p-10">
+        <h2 className="text-2xl font-bold mb-4">TickNet</h2>
+        <ul>
+          <li className="mb-[100px] mt-[100px]">
+            <Link to="/" className="block py-2 px-4 hover:bg-gray-700">
+              Home
+            </Link>
+          </li>
+          <li className="mb-8">
+            <Link to="/dashboard" className="block py-2 px-4 hover:bg-gray-700">
+              Dashboard
+            </Link>
+          </li>
+          <li className="mb-8">
+            <Link
+              to="/my-tickets"
+              className="block py-2 px-4 hover:bg-gray-700"
+            >
+              My Tickets
+            </Link>
+          </li>
+          {/* Add more sidebar items as needed */}
+        </ul>
+      </div>
+    </aside>
+  );
+};
+
+export default Aside;

--- a/src/components/Layout/DashboardLayout.jsx
+++ b/src/components/Layout/DashboardLayout.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { DashboardRouter } from "../../Routes/DashboardRouter";
+
+export const DashboardLayout = () => {
+  return (
+    <main>
+      <DashboardRouter />
+    </main>
+  );
+};

--- a/src/components/Layout/layout.jsx
+++ b/src/components/Layout/layout.jsx
@@ -11,9 +11,12 @@ export const Layout = () => {
   const isHeaderVisible =
     location.pathname === "/" || location.pathname === "/home";
 
+  // Exclude header and navbar on /dashboard route
+  const excludeHeaderAndNavbar = location.pathname === "/dashboard";
+
   return (
     <>
-      {isHeaderVisible ? <Header /> : <Navbar />}
+      {!excludeHeaderAndNavbar && (isHeaderVisible ? <Header /> : <Navbar />)}
 
       <main>
         <Router />

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import Aside  from '../components/Dashboard/Aside'
+
+export const Dashboard = () => {
+  return (
+   <Aside/>
+  )
+}


### PR DESCRIPTION
Updated the Layout component to conditionally exclude the Header and Navbar components when the route is /dashboard. This ensures a cleaner and more focused user interface for the dashboard page.